### PR TITLE
Replace deprecated config:base with config:recommended

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "config:base",
+    "config:recommended",
     ":disableDependencyDashboard",
     ":maintainLockFilesWeekly"
   ],


### PR DESCRIPTION
`config:base` is a deprecated Renovate preset alias. Rename to `config:recommended`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Renovate from deprecated `config:base` to `config:recommended` to align with current presets and remove deprecation warnings. Only updates `renovate.json`; configuration intent remains the same.

<sup>Written for commit 555f172357fff8b0eefa32cf1047bcc1418c0b1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecow/cloudflared/pull/166?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

