### PR TITLE
Run shellcheck strict

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -24,7 +24,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: ShellCheck
         uses: ludeeus/action-shellcheck@2.0.0
+        env:
+          SHELLCHECK_OPTS: --enable=all
         with:
+          severity: style
           additional_files: 'firecow_cloudflared'
 
   build:

--- a/firecow_cloudflared
+++ b/firecow_cloudflared
@@ -4,15 +4,15 @@ set -e
 
 # function that prints info message, if TUNNEL_LOGLEVEL is debug or info
 printInfo() {
-  echo "${TUNNEL_LOGLEVEL}" | grep -q -E '^(debug|info)$' || return 0
+  echo "${TUNNEL_LOGLEVEL-}" | grep -q -E '^(debug|info)$' || return 0
   formattedDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-  echo "$formattedDate INF ${1}"
+  echo "${formattedDate} INF ${1}"
 }
 
 # function that prints fatal message and exits
 printAndExit() {
   formattedDate=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-  echo >&2 "$formattedDate FAT ${2}"
+  echo >&2 "${formattedDate} FAT ${2}"
   exit "${1}"
 }
 
@@ -66,7 +66,7 @@ cat << EOF > /etc/cloudflared/config.yml
 tunnel: ${tunnel_id}
 credentials-file: /etc/cloudflared/${tunnel_id}.json
 ingress:
-  - service: ${TUNNEL_URL:-$TUNNEL_UNIX_SOCKET}
+  - service: ${TUNNEL_URL:-${TUNNEL_UNIX_SOCKET}}
 EOF
 
 unset TUNNEL_URL


### PR DESCRIPTION
The shellcheck job only failed on default-severity findings, so it now runs with every optional check enabled at style severity and the entrypoint script is adjusted to pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs ShellCheck with every optional check at style severity and fixes the script issues it flags.

- Sets `SHELLCHECK_OPTS` to `--enable=all` and severity to `style` in the QA workflow.
- Hardens variable expansions in `firecow_cloudflared` with a default for `TUNNEL_LOGLEVEL` and quoted expansions.

<sup>Written for commit 28d4c985ce05d2210adc3093bdb8d74dec42cd29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/firecow/cloudflared/pull/175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

